### PR TITLE
Update parquets and set up DuckDB

### DIFF
--- a/app/.streamlit/config.toml
+++ b/app/.streamlit/config.toml
@@ -1,6 +1,6 @@
 [theme]
-primaryColor="#1dB954"
+primaryColor="#1DB954"
 backgroundColor="#FFFFFF"
-secondaryBackgroundColor="F1F1F1"
-textColor="##191414"
+secondaryBackgroundColor="#F1F1F1"
+textColor="#191414"
 font="sans serif"

--- a/app/app-requirements.txt
+++ b/app/app-requirements.txt
@@ -1,5 +1,4 @@
 altair==4.2.2
-altgraph @ file:///System/Volumes/Data/SWE/Apps/DT/BuildRoots/BuildRoot2/ActiveBuildRoot/Library/Caches/com.apple.xbs/Sources/python3/python3-124/altgraph-0.17.2-py2.py3-none-any.whl
 async-timeout==4.0.2
 attrs==22.2.0
 blinker==1.5
@@ -8,23 +7,17 @@ certifi==2022.12.7
 charset-normalizer==3.1.0
 click==8.1.3
 colorama==0.4.6
-contourpy==1.0.5
-cycler==0.11.0
 decorator==5.1.1
+duckdb==0.7.1
 entrypoints==0.4
-fonttools==4.37.4
-future @ file:///System/Volumes/Data/SWE/Apps/DT/BuildRoots/BuildRoot2/ActiveBuildRoot/Library/Caches/com.apple.xbs/Sources/python3/python3-124/future-0.18.2-py3-none-any.whl
 gitdb==4.0.10
 GitPython==3.1.31
 idna==3.4
 importlib-metadata==6.1.0
 Jinja2==3.1.2
 jsonschema==4.17.3
-kiwisolver==1.4.4
-macholib @ file:///System/Volumes/Data/SWE/Apps/DT/BuildRoots/BuildRoot2/ActiveBuildRoot/Library/Caches/com.apple.xbs/Sources/python3/python3-124/macholib-1.15.2-py2.py3-none-any.whl
 markdown-it-py==2.2.0
 MarkupSafe==2.1.2
-matplotlib==3.6.1
 mdurl==0.1.2
 numpy==1.24.2
 packaging==23.0
@@ -36,7 +29,6 @@ pyarrow==11.0.0
 pydeck==0.8.0
 Pygments==2.14.0
 Pympler==1.0.1
-pyparsing==3.0.9
 pyrsistent==0.19.3
 python-dateutil==2.8.2
 python-decouple==3.8

--- a/app/data/playlist_analytics.parquet.gzip
+++ b/app/data/playlist_analytics.parquet.gzip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c529dea283afab584d01e83c5daf44324aa4b764ab1c100ceb8d552b39a5f4fe
-size 2899478

--- a/app/data/playlist_analytics/playlist_analytics.parquet.gzip
+++ b/app/data/playlist_analytics/playlist_analytics.parquet.gzip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:267b2f6117e9cf2e7d44fd446d24e640a8359916b7edc67df0cd97ea61ba599d
+size 2906605

--- a/app/data/playlist_preview/playlist_preview_1.parquet.gzip
+++ b/app/data/playlist_preview/playlist_preview_1.parquet.gzip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6f30af1e68afae31b1fa1f960ab244669e8f62c3904b237237e977716cd55c36
+size 49868071

--- a/app/data/playlist_preview/playlist_preview_2.parquet.gzip
+++ b/app/data/playlist_preview/playlist_preview_2.parquet.gzip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c88d17075b13586269dcce19e32c4b90474b6e54473a38e70966107552361682
+size 45736866

--- a/app/data/playlist_preview/playlist_preview_3.parquet.gzip
+++ b/app/data/playlist_preview/playlist_preview_3.parquet.gzip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:63779b5052fb5d45f5333dccb9a4615634f8f00c8dde2f9e5135776adaf0fbc7
+size 37707099

--- a/app/data/playlist_preview/playlist_preview_4.parquet.gzip
+++ b/app/data/playlist_preview/playlist_preview_4.parquet.gzip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c6262dfd2ef743351f22ee3f20cf3f5ec2c4e8cc191c914265ec7f9a0d1d04b7
+size 43819839

--- a/app/data/playlist_preview/playlist_preview_5.parquet.gzip
+++ b/app/data/playlist_preview/playlist_preview_5.parquet.gzip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e63e94cb2b0896e60f9efdecb921519a5d626e17ffdd46e91c3b2682b076cd98
+size 31060010

--- a/app/data/playlist_preview_1.parquet.gzip
+++ b/app/data/playlist_preview_1.parquet.gzip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:cbaed80acf9bf2686b5ab38146822a4b48b3f7791d337ee00347b041a3a2c9d0
-size 50014741

--- a/app/data/playlist_preview_2.parquet.gzip
+++ b/app/data/playlist_preview_2.parquet.gzip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1a2353b428a129087f6a616ee9d83bfc136daf521c49d75455709934a4bd7ae8
-size 50351388

--- a/app/data/playlist_preview_3.parquet.gzip
+++ b/app/data/playlist_preview_3.parquet.gzip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ecbbac4cb2299750ab9f10e61b0a107c8c9472e130b1639ac75c90543d38c0a3
-size 37714085

--- a/app/data/playlist_preview_4.parquet.gzip
+++ b/app/data/playlist_preview_4.parquet.gzip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3956d4c4ec6fe837e00447fea78ade6ad96578d9a727c021ffd03d5339e6c757
-size 47522260

--- a/app/data/playlist_preview_5.parquet.gzip
+++ b/app/data/playlist_preview_5.parquet.gzip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1238d584716964ff1ef972d6613ed1b8e65a1486a56d75abb0a3e1abdd9bfc73
-size 31066923

--- a/app/data/update_parquets.ipynb
+++ b/app/data/update_parquets.ipynb
@@ -1,0 +1,70 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Shortens the playlist URI in each parquet file and transfers to new location.\n",
+    "\n",
+    "# Index where playlist URI actually starts.\n",
+    "playlist_uri_start = 17\n",
+    "\n",
+    "# Update \"playlist_preview\" parquets.\n",
+    "for i in range(1, 6):\n",
+    "    df = pd.read_parquet(f\"playlist_preview_{i}.parquet.gzip\")\n",
+    "    # Remove \"spotify:playlist:\" portion of playlist URI.\n",
+    "    df[\"playlist_uri\"] = df[\"playlist_uri\"].str.slice(start=playlist_uri_start)\n",
+    "    # Place updated parquet in new location.\n",
+    "    df.to_parquet(\n",
+    "        path=f\"playlist_preview/playlist_preview_{i}.parquet.gzip\",\n",
+    "        engine=\"pyarrow\",\n",
+    "        compression=\"gzip\"\n",
+    "    )\n",
+    "\n",
+    "# Update \"playlist_analytics\" parquet.\n",
+    "df = pd.read_parquet(f\"playlist_analytics.parquet.gzip\")\n",
+    "# Remove \"spotify:playlist:\" portion of playlist URI.\n",
+    "df[\"playlist_uri\"] = df[\"playlist_uri\"].str.slice(start=playlist_uri_start)\n",
+    "# Place updated parquet in new location.\n",
+    "df.to_parquet(\n",
+    "    path=f\"playlist_analytics/playlist_analytics.parquet.gzip\",\n",
+    "    engine=\"pyarrow\",\n",
+    "    compression=\"gzip\"\n",
+    ")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.1"
+  },
+  "orig_nbformat": 4
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/app/pages/2_Select_Preloaded_Playlist.py
+++ b/app/pages/2_Select_Preloaded_Playlist.py
@@ -3,6 +3,7 @@ from st_aggrid import *
 import pandas as pd
 import plotly.express as px
 import plotly as pl
+import duckdb as ddb
 
 # Page configuration.
 st.set_page_config(
@@ -36,6 +37,31 @@ st.markdown("---")
 
 # "Select Playlist" dropdown.
 st.header("Select Playlist")
+
+
+##################### DuckDB example. #####################
+
+# Path of parquet files that will be used as table.
+playlist_preview_path = "data/playlist_preview/playlist_preview_?.parquet.gzip"
+# Name of variable that holds the DuckDB relation (table).
+playlist_preview_table = "playlist_preview"
+# Read parquet files into a DuckDB relation (table) that can then be queried.
+playlist_preview = ddb.read_parquet(playlist_preview_path)
+
+# Example of how to do a query and get the results as a DataFrame.
+playlist_uri = "3I8HGNsE2m65GaXwsarwJy"
+my_df = ddb.sql(
+    f"""
+    SELECT *
+    FROM {playlist_preview_table}
+    WHERE playlist_uri = '{playlist_uri}'
+    """
+).df()
+
+my_df
+
+###########################################################
+
 
 preloaded_playlist = st.selectbox(
     label="Preloaded Playlists:",


### PR DESCRIPTION
Update the `playlist_uri` column in the parquet files to remove the `spotify:playlist:` portion and set up DuckDB for querying the parquet files.